### PR TITLE
Add Discord discussion component to blog posts

### DIFF
--- a/src/components/Discussion.astro
+++ b/src/components/Discussion.astro
@@ -1,0 +1,24 @@
+---
+interface Props {
+    url?: string;
+}
+
+const { url } = Astro.props;
+const defaultUrl = 'https://discord.com/channels/488931914863083561/1398069128232698016';
+---
+
+<section class="mt-12 text-center">
+    {url ? (
+        <p class="text-lg">
+            <a href={url} class="text-purple-400 hover:text-purple-300">
+                Continue the conversation on the Discord thread and let us know your thoughts!
+            </a>
+        </p>
+    ) : (
+        <p class="text-lg">
+            <a href={defaultUrl} class="text-purple-400 hover:text-purple-300">
+                Continue the conversation on this post and others at the Cocoboko Cafe!
+            </a>
+        </p>
+    )}
+</section>

--- a/src/components/Discussion.astro
+++ b/src/components/Discussion.astro
@@ -7,16 +7,16 @@ const { url } = Astro.props;
 const defaultUrl = 'https://discord.com/channels/488931914863083561/1398069128232698016';
 ---
 
-<section class="mt-12 text-center">
+<section class="mt-12 mx-auto max-w-xl rounded-xl bg-gradient-to-br from-purple-900 via-purple-800 to-purple-700 border-2 border-purple-400 shadow-lg p-8 text-center">
     {url ? (
-        <p class="text-lg">
-            <a href={url} class="text-purple-400 hover:text-purple-300">
+        <p class="text-lg text-white">
+            <a href={url} target="_blank" rel="noopener noreferrer" class="font-semibold underline underline-offset-4 text-purple-200 hover:text-purple-100 transition-colors">
                 Continue the conversation on the Discord thread and let us know your thoughts!
             </a>
         </p>
     ) : (
-        <p class="text-lg">
-            <a href={defaultUrl} class="text-purple-400 hover:text-purple-300">
+        <p class="text-lg text-white">
+            <a href={defaultUrl} target="_blank" rel="noopener noreferrer" class="font-semibold underline underline-offset-4 text-purple-200 hover:text-purple-100 transition-colors">
                 Continue the conversation on this post and others at the Cocoboko Cafe!
             </a>
         </p>

--- a/src/content/blog/2025-07-24_what-is-cocoboko-studios/index.md
+++ b/src/content/blog/2025-07-24_what-is-cocoboko-studios/index.md
@@ -8,6 +8,8 @@ tags: ["studio-journey", "cocoboko"]
 image: 
     url: "/images/blog/2025-07-24_what-is-cocoboko-studios/what-is-cocoboko_header-image.webp"
     alt: "A purple question mark with a black outline where the dot of the question mark is the Cocoboko Studios logo."
+comments:
+    discord: https://discord.com/channels/488931914863083561/1398069128232698016
 ---
 
 Cocoboko Studios is an independent game studio. The plan is to make video games that I, and others like me, would like to play that I don't see in the market.

--- a/src/content/blog/2025-07-24_what-is-cocoboko-studios/index.md
+++ b/src/content/blog/2025-07-24_what-is-cocoboko-studios/index.md
@@ -66,6 +66,4 @@ In all of the podcasts, devlogs, and industry stories I have consumed over the y
 
 These conditions have taught me to appreciate the time that I do get to spend on my passion. This idea of appreciation of what I do have, ideas are part of the foundation of Cocoboko Studios, and it is these ideas that will make Cocoboko Studios unique.
 
---
-
 Writing all this down helps ground my thoughts and feelings about this journey. It’s not going to be easy—but it’s mine. I’m building it anyway. I hope you’ll come along for the ride.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,6 +11,9 @@ const blogSchema = z.object({
     }).optional(),
     category: z.enum(['devlog', 'musings']).optional(),
     tags: z.array(z.string()).optional(),
+    comments: z.object({
+        discord: z.string().url()
+    }).optional(),
 });
 
 export type BlogPost = z.infer<typeof blogSchema>;

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -3,6 +3,7 @@ import Layout from './Layout.astro';
 import Navigation from '../components/Navigation.astro';
 import Footer from '../components/Footer.astro';
 import Newsletter from '../components/Newsletter.astro';
+import Discussion from '../components/Discussion.astro';
 
 interface Props {
     title: string;
@@ -13,9 +14,12 @@ interface Props {
         alt: string;
     };
     description: string;
+    comments?: {
+        discord?: string;
+    };
 }
 
-const { title, pubDate, author, image, description } = Astro.props;
+const { title, pubDate, author, image, description, comments } = Astro.props;
 const base = import.meta.env.BASE_URL;
 ---
 
@@ -45,6 +49,7 @@ const base = import.meta.env.BASE_URL;
             <div class="prose prose-lg max-w-none prose-invert prose-p:text-gray-300 prose-headings:text-white prose-a:text-purple-400 hover:prose-a:text-purple-300">
                 <slot />
             </div>
+            <Discussion url={comments?.discord} />
         </article>
     </main>
     <Footer />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -49,6 +49,7 @@ const base = import.meta.env.BASE_URL;
             <div class="prose prose-lg max-w-none prose-invert prose-p:text-gray-300 prose-headings:text-white prose-a:text-purple-400 hover:prose-a:text-purple-300">
                 <slot />
             </div>
+            <hr class="my-12 border-t-2 opacity-70" />
             <Discussion url={comments?.discord} />
         </article>
     </main>


### PR DESCRIPTION
## Summary
- add `Discussion` component with support for custom or default Discord links
- extend blog post schema with optional `comments` config
- update blog layout to include the new component
- example use in "What is Cocoboko Studios" post

## Testing
- `npm install` *(fails: registry unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a9e3eb0b08330b8d5c3a1c1690bb3