### PR TITLE
Resilient third-party script loading with MailerLite fallback and Playwright test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^3.4.3"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1563,6 +1566,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5691,6 +5710,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.13",
@@ -23,5 +24,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^3.4.3"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cocoboko-website",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Cocoboko Studios website, built with Astro",
   "scripts": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  webServer: {
+    command: 'npm run preview -- --host 127.0.0.1 --port 4321',
+    port: 4321,
+    reuseExistingServer: false,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:4321',
+  },
+});

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -1,6 +1,21 @@
----
-const script = `<script data-collect-dnt="true" async src="https://scripts.simpleanalyticscdn.com/latest.js"></script>`;
-const noscript = `<noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif?collect-dnt=true" alt="" referrerpolicy="no-referrer-when-downgrade"/></noscript>`;
----
+<script is:inline>
+  (() => {
+    const ANALYTICS_URL = 'https://scripts.simpleanalyticscdn.com/latest.js';
 
-<Fragment set:html={`${script}${noscript}`} />
+    const loadAnalytics = async () => {
+      try {
+        await fetch(ANALYTICS_URL, { mode: 'no-cors', method: 'GET', cache: 'no-store' });
+      } catch {
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.async = true;
+      script.dataset.collectDnt = 'true';
+      script.src = ANALYTICS_URL;
+      document.head.append(script);
+    };
+
+    void loadAnalytics();
+  })();
+</script>

--- a/src/components/GetNotified.astro
+++ b/src/components/GetNotified.astro
@@ -1,5 +1,67 @@
 ---
 ---
 <div class="w-full max-w-xl flex justify-center">
-    <div class="ml-embedded w-full" data-form="b5oxmp"></div>
+  <div class="w-full space-y-4" data-mailerlite-root>
+    <div class="ml-embedded w-full" data-form="b5oxmp" data-mailerlite-embed></div>
+
+    <div
+      class="rounded-lg border border-slate-600 bg-slate-900/70 p-6 text-slate-100"
+      data-mailerlite-fallback
+      aria-live="polite"
+      hidden
+    >
+      <h3 class="text-lg font-semibold">Get notified about releases</h3>
+      <p class="mt-2 text-sm text-slate-300">
+        Our embedded signup form is currently unavailable on your network. Join us on Discord for release updates instead.
+      </p>
+      <a
+        href="https://discord.gg/uYCYCjARrF"
+        target="_blank"
+        rel="noreferrer"
+        class="mt-4 inline-flex rounded-md bg-[#5865F2] px-4 py-2 text-sm font-medium text-white transition hover:brightness-110"
+      >
+        Join Discord
+      </a>
+    </div>
+  </div>
 </div>
+
+<script is:inline>
+  (() => {
+    const root = document.querySelector('[data-mailerlite-root]');
+    if (!root) return;
+
+    const embed = root.querySelector('[data-mailerlite-embed]');
+    const fallback = root.querySelector('[data-mailerlite-fallback]');
+
+    if (!embed || !fallback) return;
+
+    const showFallback = () => {
+      fallback.hidden = false;
+    };
+
+    const hideFallback = () => {
+      fallback.hidden = true;
+    };
+
+    const observeEmbedState = () => {
+      const observer = new MutationObserver(() => {
+        if (embed.childElementCount > 0) {
+          hideFallback();
+          observer.disconnect();
+        }
+      });
+
+      observer.observe(embed, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        if (embed.childElementCount === 0) {
+          showFallback();
+        }
+      }, 3000);
+    };
+
+    window.addEventListener('mailerlite:ready', observeEmbedState, { once: true });
+    window.addEventListener('mailerlite:unavailable', showFallback, { once: true });
+  })();
+</script>

--- a/src/components/GetNotified.astro
+++ b/src/components/GetNotified.astro
@@ -12,16 +12,8 @@
     >
       <h3 class="text-lg font-semibold">Get notified about releases</h3>
       <p class="mt-2 text-sm text-slate-300">
-        Our embedded signup form is currently unavailable on your network. Join us on Discord for release updates instead.
+        Our embedded signup form is currently unavailable on your network. Come back soon for updates!
       </p>
-      <a
-        href="https://discord.gg/uYCYCjARrF"
-        target="_blank"
-        rel="noreferrer"
-        class="mt-4 inline-flex rounded-md bg-[#5865F2] px-4 py-2 text-sm font-medium text-white transition hover:brightness-110"
-      >
-        Join Discord
-      </a>
     </div>
   </div>
 </div>

--- a/src/components/GetNotified.astro
+++ b/src/components/GetNotified.astro
@@ -12,7 +12,24 @@
     >
       <h3 class="text-lg font-semibold">Get notified about releases</h3>
       <p class="mt-2 text-sm text-slate-300">
-        Our embedded signup form is currently unavailable on your network. Come back soon for updates!
+        Newsletter is coming soon! Come back soon for updates, or follow us on
+        <a
+          href="https://bsky.app/profile/cocobokostudios.bsky.social"
+          target="_blank"
+          rel="noreferrer"
+          class="underline underline-offset-2 transition hover:text-white"
+        >
+          BlueSky
+        </a>
+        or
+        <a
+          href="https://www.youtube.com/@cocobokostudios"
+          target="_blank"
+          rel="noreferrer"
+          class="underline underline-offset-2 transition hover:text-white"
+        >
+          YouTube
+        </a>
       </p>
     </div>
   </div>

--- a/src/components/MailerLiteHeader.astro
+++ b/src/components/MailerLiteHeader.astro
@@ -1,9 +1,38 @@
-<!-- MailerLite Universal -->
-<script>
-    (function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[])
-    .push(arguments);},l=d.createElement(e),l.async=1,l.src=u,
-    n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})
-    (window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
-    ml('account', '2010388');
+<script is:inline>
+  (() => {
+    const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';
+    const MAILERLITE_ACCOUNT_ID = '2010388';
+
+    const ml = window.ml || function (...args) {
+      (ml.q = ml.q || []).push(args);
+    };
+
+    window.ml = ml;
+    window.dispatchEvent(new CustomEvent('mailerlite:loading'));
+
+    const markUnavailable = () => {
+      window.dispatchEvent(new CustomEvent('mailerlite:unavailable'));
+    };
+
+    const loadMailerLite = async () => {
+      try {
+        await fetch(MAILERLITE_SCRIPT_URL, { mode: 'no-cors', method: 'GET', cache: 'no-store' });
+      } catch {
+        markUnavailable();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = MAILERLITE_SCRIPT_URL;
+      script.onerror = markUnavailable;
+      script.onload = () => {
+        window.ml('account', MAILERLITE_ACCOUNT_ID);
+        window.dispatchEvent(new CustomEvent('mailerlite:ready'));
+      };
+      document.head.append(script);
+    };
+
+    void loadMailerLite();
+  })();
 </script>
-<!-- End MailerLite Universal -->

--- a/tests/production-fallback.spec.ts
+++ b/tests/production-fallback.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('production HTML ships third-party fallback behaviour for analytics and MailerLite', async ({ request }) => {
+  const response = await request.get('/');
+  expect(response.ok()).toBeTruthy();
+
+  const html = await response.text();
+
+  expect(html).toContain("const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';");
+  expect(html).toContain('mailerlite:unavailable');
+  expect(html).toContain('data-mailerlite-fallback');
+  expect(html).toContain('Join Discord');
+
+  expect(html).toContain("const ANALYTICS_URL = 'https://scripts.simpleanalyticscdn.com/latest.js';");
+  expect(html).toContain("await fetch(ANALYTICS_URL, { mode: 'no-cors'");
+});

--- a/tests/production-fallback.spec.ts
+++ b/tests/production-fallback.spec.ts
@@ -9,7 +9,10 @@ test('production HTML ships third-party fallback behaviour for analytics and Mai
   expect(html).toContain("const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';");
   expect(html).toContain('mailerlite:unavailable');
   expect(html).toContain('data-mailerlite-fallback');
-  expect(html).toContain('Come back soon for updates!');
+  expect(html).toContain('Newsletter is coming soon!');
+  expect(html).toContain('https://bsky.app/profile/cocobokostudios.bsky.social');
+  expect(html).toContain('https://www.youtube.com/@cocobokostudios');
+  expect(html).toContain('target="_blank"');
 
   expect(html).toContain("const ANALYTICS_URL = 'https://scripts.simpleanalyticscdn.com/latest.js';");
   expect(html).toContain("await fetch(ANALYTICS_URL, { mode: 'no-cors'");

--- a/tests/production-fallback.spec.ts
+++ b/tests/production-fallback.spec.ts
@@ -9,7 +9,7 @@ test('production HTML ships third-party fallback behaviour for analytics and Mai
   expect(html).toContain("const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';");
   expect(html).toContain('mailerlite:unavailable');
   expect(html).toContain('data-mailerlite-fallback');
-  expect(html).toContain('Join Discord');
+  expect(html).toContain('Come back soon for updates!');
 
   expect(html).toContain("const ANALYTICS_URL = 'https://scripts.simpleanalyticscdn.com/latest.js';");
   expect(html).toContain("await fetch(ANALYTICS_URL, { mode: 'no-cors'");


### PR DESCRIPTION
### Motivation
- Production pages broke when CDNs for SimpleAnalytics and MailerLite were unreachable, causing console errors (`ERR_NAME_NOT_RESOLVED`/403) and the MailerLite widget to not render.  
- The site must avoid hard failures when third-party domains are blocked and provide a usable fallback UX for newsletter signup.

### Description
- Replace direct script tags with preflighted loaders that `fetch` the external URL and only inject the script when reachable, implemented in `src/components/Analytics.astro` and `src/components/MailerLiteHeader.astro`.  
- Emit lifecycle events (`mailerlite:loading`, `mailerlite:ready`, `mailerlite:unavailable`) to coordinate embed behavior and failure handling.  
- Add an in-page fallback card (Discord CTA) and a small script to `src/components/GetNotified.astro` that shows the fallback when the MailerLite embed does not appear.  
- Add Playwright test infra (`playwright.config.ts`) and an end-to-end HTML test (`tests/production-fallback.spec.ts`), and update `package.json` to include `@playwright/test` and the `test:e2e` script.

### Testing
- Built the site with `npm run build` and the build completed successfully.  
- Ran the new Playwright test with `npm run test:e2e` against the preview server and the single test passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d731a0f548833087fb112e94894830)